### PR TITLE
Add support to iOS 11

### DIFF
--- a/TOInsetGroupedTableView.podspec
+++ b/TOInsetGroupedTableView.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'TOInsetGroupedTableView'
-  s.version  = '1.0.1'
+  s.version  = '1.1.0'
   s.license  =  { :type => 'MIT', :file => 'LICENSE' }
-  s.summary  = 'An iOS 12 back-port of the grouped inset table view style in iOS 13.'
+  s.summary  = 'An iOS 11 back-port of the grouped inset table view style in iOS 13.'
   s.homepage = 'https://github.com/TimOliver/TOInsetGroupedTableView'
   s.author   = 'Tim Oliver'
   s.source   = { :git => 'https://github.com/TimOliver/TOInsetGroupedTableView.git', :tag => s.version }
-  s.platform = :ios, '12.0'
+  s.platform = :ios, '11.0'
   s.source_files = 'TOInsetGroupedTableView/**/*.{h,m}'
   s.requires_arc = true
 end


### PR DESCRIPTION
I tested this in iOS 11 and discovered that it was broken. The table cells weren't being rounded correctly.

It turns out that calling `layoutIfNeeded` on the cells doesn't update the placement of the separator lines at that time in iOS 11 like it does in iOS 12.

After setting a KVO observer to every single property of `UITableViewCell`, I discovered that `setSelected:` is always called on each cell as they're placed into the table view, after the layout has happened.

As such, this PR changes the logic to also register an observer for `selected` on each table cell, and performs the rounding on the cell at that point.

Tested and working on both iOS 11 and iOS 12 now. :)